### PR TITLE
Push packages to ms-nuget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           dotnet-version: '3.1.x'
           source-url: https://nuget.pkg.github.com/LottieFiles/index.json
         env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_AUTH_TOKEN: ${{ secrets.MS_NUGET_TOKEN }}
       
       - name: Release
         run: yarn release

--- a/release.config.js
+++ b/release.config.js
@@ -58,7 +58,7 @@ module.exports = {
         cli: "dotnet",
         nupkgDir: "dist",
         projectRoot: 'LottieFiles.DotLottie',
-        source: "https://nuget.pkg.github.com/LottieFiles/index.json"
+        source: "https://api.nuget.org/v3/index.json"
       }
     ],
     [


### PR DESCRIPTION
Since the library is now stable, we should push packages to ms-nuget feed.